### PR TITLE
Fix docker zencart download link & volume

### DIFF
--- a/docker/bin/Dockerfile
+++ b/docker/bin/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4-apache
 
-ENV ZENCART_FN=zen-cart-v1.5.7c-03052021
+ENV ZENCART_FN=zencart-1.5.7c
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -22,7 +22,7 @@ RUN docker-php-source extract \
     && docker-php-ext-install opcache
 RUN a2enmod rewrite
 
-ADD https://nchc.dl.sourceforge.net/project/zencart/CURRENT%20-%20Zen%20Cart%201.5.x%20Series/${ZENCART_FN}.zip /tmp/${ZENCART_FN}.zip
+ADD https://github.com/zencart/zencart/archive/refs/tags/v1.5.7c.zip /tmp/${ZENCART_FN}.zip
 
 ARG TIMEZONE
 WORKDIR /tmp

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - 80:80
     depends_on:
       - db
-    volumes:
-      - web_data:/var/www/html
   db:
     image: mysql:5.7
     volumes:
@@ -24,4 +22,3 @@ services:
       - 3306:3306
 volumes:
   db_data:
-  web_data:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container setup to use a simplified Zen Cart package identifier and a more reliable GitHub source for downloads.
  - Streamlined the deployment configuration by removing an obsolete volume mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->