### PR TITLE
Fix/db query to update configuration

### DIFF
--- a/YOUR_ADMIN_FOLDER/tawk_to_widget_manager.php
+++ b/YOUR_ADMIN_FOLDER/tawk_to_widget_manager.php
@@ -50,25 +50,25 @@ function setWidget($page_id, $widget_id) {
     $widget_id = trim($widget_id);
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_title, configuration_key, configuration_value, configuration_description)
-        values('Tawk.to Page ID', '" . TAWK_TO_PAGE_ID_FIELD . "', '" . $db->prepare_input($page_id) . "', 'Tawk.to Page ID')
+        (configuration_key, configuration_value, configuration_title, configuration_description)
+        values('" . TAWK_TO_PAGE_ID_FIELD . "', '" . $db->prepare_input($page_id) . "', 'Tawk.to Property ID', 'Tawk.to Property ID')
         on duplicate key update configuration_value='" . $db->prepare_input($page_id) . "'");
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_title, configuration_key, configuration_value, configuration_description)
-        values('Tawk.to Widget ID', '" . TAWK_TO_WIDGET_ID_FIELD . "', '" . $db->prepare_input($widget_id) . "', 'Tawk.to Widget ID')
+        (configuration_key, configuration_value, configuration_title, configuration_description)
+        values('" . TAWK_TO_WIDGET_ID_FIELD . "', '" . $db->prepare_input($widget_id) . "', 'Tawk.to Widget ID', 'Tawk.to Widget ID')
         on duplicate key update configuration_value='" . $db->prepare_input($widget_id) . "'");
 }
 
 function removeWidget() {
     global $db;
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_title, configuration_key, configuration_value, configuration_description)
-        values('Tawk.to Page ID', '" . TAWK_TO_PAGE_ID_FIELD . "', '', 'Tawk.to Page ID')
+        (configuration_key, configuration_value, configuration_title, configuration_description)
+        values('" . TAWK_TO_PAGE_ID_FIELD . "', '', 'Tawk.to Property ID', 'Tawk.to Property ID')
         on duplicate key update configuration_value=''");
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_title, configuration_key, configuration_value, configuration_description)
-        values('Tawk.to Widget ID', '" . TAWK_TO_WIDGET_ID_FIELD . "', '', 'Tawk.to Widget ID')
+        (configuration_key, configuration_value, configuration_title, configuration_description)
+        values('" . TAWK_TO_WIDGET_ID_FIELD . "', '', 'Tawk.to Widget ID', 'Tawk.to Widget ID')
         on duplicate key update configuration_value=''");
 }

--- a/YOUR_ADMIN_FOLDER/tawk_to_widget_manager.php
+++ b/YOUR_ADMIN_FOLDER/tawk_to_widget_manager.php
@@ -50,25 +50,25 @@ function setWidget($page_id, $widget_id) {
     $widget_id = trim($widget_id);
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_key, configuration_value)
-        values('" . TAWK_TO_PAGE_ID_FIELD . "', '" . $db->prepare_input($page_id) . "')
+        (configuration_title, configuration_key, configuration_value, configuration_description)
+        values('Tawk.to Page ID', '" . TAWK_TO_PAGE_ID_FIELD . "', '" . $db->prepare_input($page_id) . "', 'Tawk.to Page ID')
         on duplicate key update configuration_value='" . $db->prepare_input($page_id) . "'");
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_key, configuration_value)
-        values('" . TAWK_TO_WIDGET_ID_FIELD . "', '" . $db->prepare_input($widget_id) . "')
+        (configuration_title, configuration_key, configuration_value, configuration_description)
+        values('Tawk.to Widget ID', '" . TAWK_TO_WIDGET_ID_FIELD . "', '" . $db->prepare_input($widget_id) . "', 'Tawk.to Widget ID')
         on duplicate key update configuration_value='" . $db->prepare_input($widget_id) . "'");
 }
 
 function removeWidget() {
     global $db;
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_key, configuration_value)
-        values('" . TAWK_TO_PAGE_ID_FIELD . "', '')
+        (configuration_title, configuration_key, configuration_value, configuration_description)
+        values('Tawk.to Page ID', '" . TAWK_TO_PAGE_ID_FIELD . "', '', 'Tawk.to Page ID')
         on duplicate key update configuration_value=''");
 
     $db->Execute("insert into " . TABLE_CONFIGURATION . "
-        (configuration_key, configuration_value)
-        values('" . TAWK_TO_WIDGET_ID_FIELD . "', '')
+        (configuration_title, configuration_key, configuration_value, configuration_description)
+        values('Tawk.to Widget ID', '" . TAWK_TO_WIDGET_ID_FIELD . "', '', 'Tawk.to Widget ID')
         on duplicate key update configuration_value=''");
 }


### PR DESCRIPTION
```
-> PHP Fatal error: 1364:Field 'configuration_title' doesn't have a default value :: insert into configuration
        (configuration_key, configuration_value)
        values('tawk_to_page_id', '...')
        on duplicate key update configuration_value='...' ==> (as called by) /var/www/html/rOost-oqL-wReck/tawk_to_widget_manager.php on line 55
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced widget configuration management with added descriptive labels and contextual information for clearer identification of widget properties.
  - These improvements streamline the management experience by presenting widget settings in a more intuitive and user-friendly manner, making it easier to recognize key configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->